### PR TITLE
pin verifiers version and upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "matplotlib",
     "plotly",
     "mlflow",
-    "verifiers",
+    "verifiers==0.1.3",
     "vf-exts",
 ]
 


### PR DESCRIPTION
This pins the `verifiers` version to 1.0.3 and copes with a small breaking change made in this version (properly awaits certain functions that were previously synchronous).