### PR TITLE
Add magistral changes

### DIFF
--- a/examples/configs/rl/alphabet_sort/qwen3_4B.yaml
+++ b/examples/configs/rl/alphabet_sort/qwen3_4B.yaml
@@ -2,10 +2,11 @@
 grpo:
   num_prompts_per_step: 3
   num_generations_per_prompt: 16
-  max_rollout_turns: 10 # prefer to use verifiers to set turn limits
+  max_rollout_turns: 10
   max_num_steps: 1000000
-  normalize_rewards: true
+  normalize_rewards: false
   use_leave_one_out_baseline: true
+  minibatch_advantage_renorm: true  # Set to true to enable z-score renorm for stability
   val_period: 0
   val_at_start: false
   max_val_samples: 0
@@ -13,11 +14,10 @@ grpo:
   seed: 42
 
 loss_fn:
-  reference_policy_kl_penalty: 0.01
-  ratio_clip_min: 0.2
-  ratio_clip_max: 0.2
+  reference_policy_kl_penalty: 0  # if disabled, reference model won't be loaded and saves memory
+  ratio_clip_min: 0.2 
+  ratio_clip_max: 0.28 # 0.26-0.28 range per magistral report
   ratio_clip_c: null
-  # (default off) loss formulation improvements (docs/guides/grpo.md#loss)
   use_on_policy_kl_approximation: false
   use_importance_sampling_correction: false
   token_level_loss: true

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -350,6 +350,10 @@ def setup(
         weights_path = None
         optimizer_path = None
 
+    init_reference_model = loss_config["reference_policy_kl_penalty"] != 0
+    if not init_reference_model:
+        print("KL coefficient is 0, skipping reference model loading")
+    
     policy = Policy(
         cluster=train_cluster,
         config=policy_config,
@@ -357,6 +361,7 @@ def setup(
         weights_path=weights_path,
         optimizer_path=optimizer_path,
         init_optimizer=True,
+        init_reference_model=init_reference_model,
     )
 
     # if it is not colocated inference, initialize collective communication for update weights
@@ -710,9 +715,14 @@ def grpo_train(
             print("▶ Computing logprobs...")
             with timer.time("policy_and_reference_logprobs"):
                 fprop_logprobs = policy.get_logprobs(train_data)["logprobs"]
-                reference_logprobs = policy.get_reference_policy_logprobs(train_data)[
-                    "reference_logprobs"
-                ]
+                
+                if master_config["loss_fn"]["reference_policy_kl_penalty"] != 0:
+                    reference_logprobs = policy.get_reference_policy_logprobs(train_data)[
+                        "reference_logprobs"
+                    ]
+                else:
+                    reference_logprobs = torch.zeros_like(fprop_logprobs)
+                
                 train_data["prev_logprobs"] = fprop_logprobs
                 train_data["reference_policy_logprobs"] = reference_logprobs
 

--- a/nemo_rl/algorithms/grpo.py
+++ b/nemo_rl/algorithms/grpo.py
@@ -84,6 +84,7 @@ class GRPOConfig(TypedDict):
     max_rollout_turns: NotRequired[int]
     normalize_rewards: bool
     use_leave_one_out_baseline: bool
+    minibatch_advantage_renorm: NotRequired[bool]
     val_period: int
     val_batch_size: int
     val_at_start: bool
@@ -657,14 +658,24 @@ def grpo_train(
                         "use_leave_one_out_baseline"
                     ],
                 )
+                # Simple group baseline: A_i = R_i - R̄ (no std normalization)
                 advantages = (rewards - baseline).unsqueeze(-1)
 
-                if master_config["grpo"]["normalize_rewards"]:
-                    # don't sharpen the ones with no variation
-                    zero_std_mask = std > 0
-                    advantages[zero_std_mask] = (
-                        advantages[zero_std_mask] / std.unsqueeze(-1)[zero_std_mask]
-                    )
+                # Filter zero-advantage groups (all generations have identical rewards)
+                zero_variance_mask = std == 0
+                if zero_variance_mask.any():
+                    num_filtered = zero_variance_mask.sum().item()
+                    print(f"Filtering {num_filtered} samples from {zero_variance_mask.sum().item() // master_config['grpo']['num_generations_per_prompt']} zero-advantage groups")
+                    repeated_batch["loss_multiplier"] = repeated_batch["loss_multiplier"] * (~zero_variance_mask).float()
+
+                # Optional: z-score advantages within the mini-batch for stability
+                if master_config["grpo"].get("minibatch_advantage_renorm", False):
+                    valid_advantages = advantages[repeated_batch["loss_multiplier"] > 0]
+                    if len(valid_advantages) > 1:
+                        adv_mean = valid_advantages.mean()
+                        adv_std = valid_advantages.std()
+                        if adv_std > 0:
+                            advantages = (advantages - adv_mean) / adv_std
 
             with timer.time("data_processing"):
                 # Add loss mask and advantages to each message in LLMMessageLogType


### PR DESCRIPTION
Implements GRPO enhancements from Magistral:

 - Skip reference model loading when KL coefficient is 0 (saves memory/compute)
 - Filter zero-advantage groups before loss computation
 - Replace std-normalized advantages with simple group baseline (A_i = R_i - R̄)
 - Add optional mini-batch advantage renorm flag for early training stability

Note: Still getting high vram usage as reported by maziyar - while this approach works and optimizes properly, I cannot test the validity at longer intervals.