### PR TITLE
Add support for dion's Muon optimizer interface

### DIFF
--- a/examples/configs/rl/reverser/qwen3_0.6B_2gpu.yaml
+++ b/examples/configs/rl/reverser/qwen3_0.6B_2gpu.yaml
@@ -76,7 +76,7 @@ policy:
   max_grad_norm: 1.0
 
   optimizer:
-    name: "dion.Muon"
+    name: "torch.optim.AdamW"
     kwargs:
       lr: 3.0e-6
       weight_decay: 0.01

--- a/examples/configs/rl/reverser/qwen3_0.6B_2gpu_muon.yaml
+++ b/examples/configs/rl/reverser/qwen3_0.6B_2gpu_muon.yaml
@@ -79,7 +79,7 @@ policy:
     name: "dion.MuonReference"
     scalar_optim: "adamw"
     kwargs:
-      lr: 3.0e-4
+      lr: 3.0e-5
       # mu: 0.95
       weight_decay: 0.01
       betas: [0.9, 0.999]

--- a/examples/configs/rl/reverser/qwen3_0.6B_2gpu_muon.yaml
+++ b/examples/configs/rl/reverser/qwen3_0.6B_2gpu_muon.yaml
@@ -76,28 +76,28 @@ policy:
   max_grad_norm: 1.0
 
   optimizer:
-    name: "dion.Muon"
+    name: "dion.MuonReference"
+    scalar_optim: "adamw"
     kwargs:
-      lr: 3.0e-6
+      lr: 3.0e-4
+      # mu: 0.95
       weight_decay: 0.01
       betas: [0.9, 0.999]
-      eps: 1e-8
+      # eps: 1e-8
       # when using Dtensor, we need to set foreach
       # and fused to False
-      foreach: False
-      fused: False
 
   scheduler:
-    - name: "torch.optim.lr_scheduler.LinearLR"
-      kwargs:
-        start_factor: 0.1
-        end_factor: 1.0
-        total_iters: 50
+    # - name: "torch.optim.lr_scheduler.LinearLR"
+    #   kwargs:
+    #     start_factor: 0.1
+    #     end_factor: 1.0
+    #     total_iters: 50
     - name: "torch.optim.lr_scheduler.ConstantLR"
       kwargs:
         factor: 1.0
         total_iters: 10000000000
-    - milestones: [50]
+    - milestones: []
 
   generation:
     backend: "vllm_http"

--- a/examples/configs/rl/reverser/qwen3_30B_A3B_multinode.yaml
+++ b/examples/configs/rl/reverser/qwen3_30B_A3B_multinode.yaml
@@ -122,7 +122,7 @@ policy:
       enabled: false
       resources:
         gpus_per_node: 8
-        num_nodes: null
+        num_nodes: 1
 
 data:
   max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len

--- a/examples/configs/rl/reverser/qwen3_30B_A3B_multinode.yaml
+++ b/examples/configs/rl/reverser/qwen3_30B_A3B_multinode.yaml
@@ -1,0 +1,155 @@
+# GRPO Algorithm Configuration
+grpo:
+  num_prompts_per_step: 2
+  num_generations_per_prompt: 16
+  max_rollout_turns: 1 # for multi-turn rollouts. Math Environments just have 1 turn (answering the question)
+  max_num_steps: 1000000
+  normalize_rewards: true
+  use_leave_one_out_baseline: true
+  val_period: 0
+  val_at_start: false
+  max_val_samples: null
+  val_batch_size: null
+  seed: 42
+
+loss_fn:
+  reference_policy_kl_penalty: 0.01
+  ratio_clip_min: 0.2
+  ratio_clip_max: 0.2
+  ratio_clip_c: null
+  # (default off) loss formulation improvements (docs/guides/grpo.md#loss)
+  use_on_policy_kl_approximation: false
+  use_importance_sampling_correction: false
+  token_level_loss: true
+
+checkpointing:
+  enabled: true
+  checkpoint_dir: "results/grpo_vf_reverser_30BA3B"
+  metric_name: "val_reward"
+  higher_is_better: true
+  keep_top_k: 3
+  save_period: 10
+  checkpoint_must_save_by: null
+
+policy:
+  model_name: "Qwen/Qwen3-30B-A3B-Instruct-2507"
+  tokenizer:
+    name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
+  train_global_batch_size: 8
+  train_micro_batch_size: 2
+  generation_batch_size: 32 # Only used when generating using HF backend
+  logprob_batch_size: 4
+  max_total_sequence_length: 512
+  precision: "bfloat16"
+
+  dtensor_cfg:
+    enabled: false
+  
+  dtensor_v2_cfg:
+    enabled: true
+    cpu_offload: False
+    sequence_parallel: false
+    activation_checkpointing: true
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    pipeline_parallel_size: 1
+    expert_parallel_size: 8
+    custom_parallel_plan: null
+  # See docs/design-docs/sequence-packing-and-dynamic-batching.md 
+  # for more details on dynamic batching and sequence packing.
+  dynamic_batching:
+    enabled: False
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    sequence_length_round: 64
+
+  sequence_packing:
+    enabled: True
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    algorithm: "modified_first_fit_decreasing"
+    sequence_length_round: 64
+
+  # makes the training sequence length divisible by the tensor parallel size
+  # this is useful for sequence parallel training
+  make_sequence_length_divisible_by: ${policy.dtensor_v2_cfg.tensor_parallel_size}
+  max_grad_norm: 1.0
+
+  optimizer:
+    # name: "torch.optim.AdamW"
+    name: "torchao.optim.AdamW8bit"
+    kwargs:
+      lr: 3.0e-6
+      weight_decay: 0.01
+      betas: [0.9, 0.999]
+      eps: 1e-8
+      # when using Dtensor, we need to set foreach
+      # and fused to False
+      # foreach: False
+      # fused: False
+
+  scheduler:
+    - name: "torch.optim.lr_scheduler.LinearLR"
+      kwargs:
+        start_factor: 0.1
+        end_factor: 1.0
+        total_iters: 50
+    - name: "torch.optim.lr_scheduler.ConstantLR"
+      kwargs:
+        factor: 1.0
+        total_iters: 10000000000
+    - milestones: [50]
+
+  generation:
+    backend: "vllm_http"
+    max_new_tokens: 256
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_token_ids: null
+    stop_strings: null
+    server_timeout: 60
+    vllm_cfg:
+      async_engine: false
+      precision: ${policy.precision}
+      tensor_parallel_size: 1
+      pipeline_parallel_size: 1
+      gpu_memory_utilization: 0.6
+      max_model_len: ${policy.max_total_sequence_length}
+      enforce_eager: False
+      extra_cli_args: []
+    colocated:
+      enabled: false
+      resources:
+        gpus_per_node: 8
+        num_nodes: null
+
+data:
+  max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len
+  shuffle: false
+
+env:
+  vf:
+    environment_name: "vf_reverse_text"
+
+logger:
+  log_dir: "logs"  # Base directory for all logs
+  num_val_samples_to_print: 0 # Number of validation samples to pretty print on terminal
+  wandb_enabled: true
+  tensorboard_enabled: false
+  mlflow_enabled: false  # Disable MLflow logging
+  monitor_gpus: true  # If true, will monitor GPU usage and log to wandb and/or tensorboard
+  wandb:
+    project: "nemo-grpo-dev"
+    name: "grpo-vf-reverser-30BA3B"
+  tensorboard: {}
+  mlflow:
+    experiment_name: "grpo-vf-reverser-30BA3B"
+    run_name: "grpo-vf-reverser-30BA3B"
+  gpu_monitoring:
+    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
+    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
+
+cluster:
+  gpus_per_node: 8
+  num_nodes: 2

--- a/examples/configs/rl/reverser/qwen3_32B_16gpu.yaml
+++ b/examples/configs/rl/reverser/qwen3_32B_16gpu.yaml
@@ -111,7 +111,7 @@ policy:
     vllm_cfg:
       async_engine: false
       precision: ${policy.precision}
-      tensor_parallel_size: 1
+      tensor_parallel_size: 4
       pipeline_parallel_size: 1
       gpu_memory_utilization: 0.6
       max_model_len: ${policy.max_total_sequence_length}

--- a/examples/configs/rl/reverser/qwen3_32B_16gpu.yaml
+++ b/examples/configs/rl/reverser/qwen3_32B_16gpu.yaml
@@ -1,0 +1,154 @@
+# GRPO Algorithm Configuration
+grpo:
+  num_prompts_per_step: 16
+  num_generations_per_prompt: 16
+  max_rollout_turns: 1 # for multi-turn rollouts. Math Environments just have 1 turn (answering the question)
+  max_num_steps: 1000000
+  normalize_rewards: true
+  use_leave_one_out_baseline: true
+  val_period: 0
+  val_at_start: false
+  max_val_samples: 256
+  val_batch_size: 256
+  seed: 42
+
+loss_fn:
+  reference_policy_kl_penalty: 0.01
+  ratio_clip_min: 0.2
+  ratio_clip_max: 0.2
+  ratio_clip_c: null
+  # (default off) loss formulation improvements (docs/guides/grpo.md#loss)
+  use_on_policy_kl_approximation: false
+  use_importance_sampling_correction: false
+  token_level_loss: true
+
+checkpointing:
+  enabled: true
+  checkpoint_dir: "results/grpo_vf_reverser_600M"
+  metric_name: "step"
+  higher_is_better: true
+  keep_top_k: 3
+  save_period: 10
+  checkpoint_must_save_by: null
+
+policy:
+  model_name: "Qwen/Qwen3-32B"
+  tokenizer:
+    name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
+  train_global_batch_size: 256
+  train_micro_batch_size: 4
+  generation_batch_size: -1 # Only used when generating using HF backend
+  logprob_batch_size: 4
+  max_total_sequence_length: 512
+  precision: "bfloat16"
+
+  dtensor_cfg:
+    enabled: false
+  
+  dtensor_v2_cfg:
+    enabled: true
+    cpu_offload: false
+    sequence_parallel: false
+    activation_checkpointing: false
+    tensor_parallel_size: 4
+    context_parallel_size: 1
+    pipeline_parallel_size: 1
+    expert_parallel_size: 1
+    custom_parallel_plan: null
+  # See docs/design-docs/sequence-packing-and-dynamic-batching.md 
+  # for more details on dynamic batching and sequence packing.
+  dynamic_batching:
+    enabled: False
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    sequence_length_round: 64
+
+  sequence_packing:
+    enabled: True
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    algorithm: "modified_first_fit_decreasing"
+    sequence_length_round: 64
+
+  # makes the training sequence length divisible by the tensor parallel size
+  # this is useful for sequence parallel training
+  make_sequence_length_divisible_by: ${policy.dtensor_v2_cfg.tensor_parallel_size}
+  max_grad_norm: 1.0
+
+  optimizer:
+    name: "dion.MuonReference"
+    scalar_optim: "adamw"
+    kwargs:
+      lr: 3.0e-5
+      # mu: 0.95
+      weight_decay: 0.01
+      betas: [0.9, 0.999]
+      # eps: 1e-8
+      # when using Dtensor, we need to set foreach
+      # and fused to False
+
+  scheduler:
+    - name: "torch.optim.lr_scheduler.LinearLR"
+      kwargs:
+        start_factor: 0.1
+        end_factor: 1.0
+        total_iters: 50
+    - name: "torch.optim.lr_scheduler.ConstantLR"
+      kwargs:
+        factor: 1.0
+        total_iters: 10000000000
+    - milestones: [50]
+
+  generation:
+    backend: "vllm_http"
+    max_new_tokens: null
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_token_ids: null
+    stop_strings: null
+    server_timeout: 60
+    vllm_cfg:
+      async_engine: false
+      precision: ${policy.precision}
+      tensor_parallel_size: 1
+      pipeline_parallel_size: 1
+      gpu_memory_utilization: 0.6
+      max_model_len: ${policy.max_total_sequence_length}
+      enforce_eager: False
+      extra_cli_args: []
+    colocated:
+      enabled: false
+      resources:
+        gpus_per_node: 8
+        num_nodes: 1
+
+data:
+  max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len
+  shuffle: false
+
+env:
+  vf:
+    environment_name: "vf_reverse_text"
+
+logger:
+  log_dir: "logs"  # Base directory for all logs
+  num_val_samples_to_print: 0 # Number of validation samples to pretty print on terminal
+  wandb_enabled: true
+  tensorboard_enabled: false
+  mlflow_enabled: false  # Disable MLflow logging
+  monitor_gpus: true  # If true, will monitor GPU usage and log to wandb and/or tensorboard
+  wandb:
+    project: "nemo-grpo-dev"
+    name: "grpo-vf-reverser-4B"
+  tensorboard: {}
+  mlflow:
+    experiment_name: "grpo-vf-reverser-4B"
+    run_name: "grpo-vf-reverser-4B"
+  gpu_monitoring:
+    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
+    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
+
+cluster:
+  gpus_per_node: 8
+  num_nodes: 2

--- a/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
+++ b/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
@@ -111,7 +111,7 @@ policy:
     vllm_cfg:
       async_engine: false
       precision: ${policy.precision}
-      tensor_parallel_size: 4
+      tensor_parallel_size: 8
       pipeline_parallel_size: 1
       gpu_memory_utilization: 0.6
       max_model_len: ${policy.max_total_sequence_length}
@@ -121,7 +121,7 @@ policy:
       enabled: false
       resources:
         gpus_per_node: 8
-        num_nodes: 1
+        num_nodes: 2
 
 data:
   max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len

--- a/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
+++ b/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
@@ -150,5 +150,5 @@ logger:
     flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
 
 cluster:
-  gpus_per_node: 2
-  num_nodes: 1
+  gpus_per_node: 8
+  num_nodes: 2

--- a/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
+++ b/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
@@ -50,7 +50,7 @@ policy:
     cpu_offload: false
     sequence_parallel: false
     activation_checkpointing: false
-    tensor_parallel_size: 4
+    tensor_parallel_size: 2
     context_parallel_size: 1
     pipeline_parallel_size: 1
     expert_parallel_size: 1
@@ -111,7 +111,7 @@ policy:
     vllm_cfg:
       async_engine: false
       precision: ${policy.precision}
-      tensor_parallel_size: 8
+      tensor_parallel_size: 1
       pipeline_parallel_size: 1
       gpu_memory_utilization: 0.6
       max_model_len: ${policy.max_total_sequence_length}
@@ -120,8 +120,8 @@ policy:
     colocated:
       enabled: false
       resources:
-        gpus_per_node: 4
-        num_nodes: 2
+        gpus_per_node: 6
+        num_nodes: 1
 
 data:
   max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len

--- a/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
+++ b/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
@@ -1,0 +1,154 @@
+# GRPO Algorithm Configuration
+grpo:
+  num_prompts_per_step: 16
+  num_generations_per_prompt: 16
+  max_rollout_turns: 1 # for multi-turn rollouts. Math Environments just have 1 turn (answering the question)
+  max_num_steps: 1000000
+  normalize_rewards: true
+  use_leave_one_out_baseline: true
+  val_period: 0
+  val_at_start: false
+  max_val_samples: 256
+  val_batch_size: 256
+  seed: 42
+
+loss_fn:
+  reference_policy_kl_penalty: 0.01
+  ratio_clip_min: 0.2
+  ratio_clip_max: 0.2
+  ratio_clip_c: null
+  # (default off) loss formulation improvements (docs/guides/grpo.md#loss)
+  use_on_policy_kl_approximation: false
+  use_importance_sampling_correction: false
+  token_level_loss: true
+
+checkpointing:
+  enabled: true
+  checkpoint_dir: "results/grpo_vf_reverser_600M"
+  metric_name: "step"
+  higher_is_better: true
+  keep_top_k: 3
+  save_period: 10
+  checkpoint_must_save_by: null
+
+policy:
+  model_name: "Qwen/Qwen3-4B-Instruct-2507"
+  tokenizer:
+    name: ${policy.model_name} ## specify if you'd like to use a tokenizer different from the model's default
+  train_global_batch_size: 256
+  train_micro_batch_size: 4
+  generation_batch_size: -1 # Only used when generating using HF backend
+  logprob_batch_size: 4
+  max_total_sequence_length: 512
+  precision: "bfloat16"
+
+  dtensor_cfg:
+    enabled: false
+  
+  dtensor_v2_cfg:
+    enabled: true
+    cpu_offload: false
+    sequence_parallel: false
+    activation_checkpointing: false
+    tensor_parallel_size: 4
+    context_parallel_size: 1
+    pipeline_parallel_size: 1
+    expert_parallel_size: 1
+    custom_parallel_plan: null
+  # See docs/design-docs/sequence-packing-and-dynamic-batching.md 
+  # for more details on dynamic batching and sequence packing.
+  dynamic_batching:
+    enabled: False
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    sequence_length_round: 64
+
+  sequence_packing:
+    enabled: True
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    algorithm: "modified_first_fit_decreasing"
+    sequence_length_round: 64
+
+  # makes the training sequence length divisible by the tensor parallel size
+  # this is useful for sequence parallel training
+  make_sequence_length_divisible_by: ${policy.dtensor_v2_cfg.tensor_parallel_size}
+  max_grad_norm: 1.0
+
+  optimizer:
+    name: "dion.Muon"
+    kwargs:
+      lr: 3.0e-6
+      weight_decay: 0.01
+      betas: [0.9, 0.999]
+      eps: 1e-8
+      # when using Dtensor, we need to set foreach
+      # and fused to False
+      foreach: False
+      fused: False
+
+  scheduler:
+    - name: "torch.optim.lr_scheduler.LinearLR"
+      kwargs:
+        start_factor: 0.1
+        end_factor: 1.0
+        total_iters: 50
+    - name: "torch.optim.lr_scheduler.ConstantLR"
+      kwargs:
+        factor: 1.0
+        total_iters: 10000000000
+    - milestones: [50]
+
+  generation:
+    backend: "vllm_http"
+    max_new_tokens: null
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_token_ids: null
+    stop_strings: null
+    server_timeout: 60
+    vllm_cfg:
+      async_engine: false
+      precision: ${policy.precision}
+      tensor_parallel_size: 4
+      pipeline_parallel_size: 1
+      gpu_memory_utilization: 0.6
+      max_model_len: ${policy.max_total_sequence_length}
+      enforce_eager: False
+      extra_cli_args: []
+    colocated:
+      enabled: false
+      resources:
+        gpus_per_node: 8
+        num_nodes: 1
+
+data:
+  max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len
+  shuffle: false
+
+env:
+  vf:
+    environment_name: "vf_reverse_text"
+
+logger:
+  log_dir: "logs"  # Base directory for all logs
+  num_val_samples_to_print: 0 # Number of validation samples to pretty print on terminal
+  wandb_enabled: true
+  tensorboard_enabled: false
+  mlflow_enabled: false  # Disable MLflow logging
+  monitor_gpus: true  # If true, will monitor GPU usage and log to wandb and/or tensorboard
+  wandb:
+    project: "nemo-grpo-dev"
+    name: "grpo-vf-reverser-4B"
+  tensorboard: {}
+  mlflow:
+    experiment_name: "grpo-vf-reverser-4B"
+    run_name: "grpo-vf-reverser-4B"
+  gpu_monitoring:
+    collection_interval: 10  # How often to collect GPU usage metrics (in seconds)
+    flush_interval: 10  # How often to flush GPU usage metrics to the loggers (in seconds)
+
+cluster:
+  gpus_per_node: 2
+  num_nodes: 1

--- a/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
+++ b/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
@@ -121,7 +121,7 @@ policy:
       enabled: false
       resources:
         gpus_per_node: 6
-        num_nodes: 1
+        num_nodes: null
 
 data:
   max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len

--- a/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
+++ b/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
@@ -120,7 +120,7 @@ policy:
     colocated:
       enabled: false
       resources:
-        gpus_per_node: 8
+        gpus_per_node: 4
         num_nodes: 2
 
 data:

--- a/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
+++ b/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
@@ -50,7 +50,7 @@ policy:
     cpu_offload: false
     sequence_parallel: false
     activation_checkpointing: false
-    tensor_parallel_size: 2
+    tensor_parallel_size: 4
     context_parallel_size: 1
     pipeline_parallel_size: 1
     expert_parallel_size: 1
@@ -120,8 +120,8 @@ policy:
     colocated:
       enabled: false
       resources:
-        gpus_per_node: 6
-        num_nodes: null
+        gpus_per_node: 8
+        num_nodes: 1
 
 data:
   max_input_seq_length: ${policy.max_total_sequence_length} # upper bound, real truncation occurs at vllm.max_model_len

--- a/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
+++ b/examples/configs/rl/reverser/qwen3_4B_16gpu.yaml
@@ -76,16 +76,16 @@ policy:
   max_grad_norm: 1.0
 
   optimizer:
-    name: "dion.Muon"
+    name: "dion.MuonReference"
+    scalar_optim: "adamw"
     kwargs:
-      lr: 3.0e-6
+      lr: 3.0e-5
+      # mu: 0.95
       weight_decay: 0.01
       betas: [0.9, 0.999]
-      eps: 1e-8
+      # eps: 1e-8
       # when using Dtensor, we need to set foreach
       # and fused to False
-      foreach: False
-      fused: False
 
   scheduler:
     - name: "torch.optim.lr_scheduler.LinearLR"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,8 @@ dependencies = [
     "verifiers==0.1.3",
     "vf-exts",
     "flash-attn==2.7.4.post1",
-    "vllm>=0.10.0"
+    "vllm>=0.10.0",
+    "dion @ https://github.com/microsoft/dion.git"
 ]
 
 [project.optional-dependencies]

--- a/rlkit/config/rl/policy/__init__.py
+++ b/rlkit/config/rl/policy/__init__.py
@@ -45,6 +45,9 @@ class RewardModelConfig(TypedDict):
 
 class PytorchOptimizerConfig(TypedDict):
     name: str
+    scalar_optim: NotRequired[str | None]
+    scalar_optim_kwargs: NotRequired[dict[str, Any] | None]
+    non_muon_params: NotRequired[list[str] | None]
     kwargs: dict[str, Any]
 
 

--- a/rlkit/models/policy/v2_policy_worker.py
+++ b/rlkit/models/policy/v2_policy_worker.py
@@ -337,13 +337,9 @@ class DTensorV2PolicyWorker:
         self.adapter = None
         self._custom_parallelize_function: Optional[Callable] = None
 
-        if self.uses_custom_model and self.rank == 0:
-            logging.info(f"Using custom model implementation for {model_name}")
-        else:
-            logging.info(f"Using HuggingFace implementation for {model_name}")
-
         full_state_dict = None
         if self.uses_custom_model:
+            logging.info(f"Using custom model implementation for {model_name}")
             custom_model_class, model_args, adapter_class, model_parallelize_function = (
                 custom_model_setup  # type: ignore[arg-type]
             )
@@ -371,6 +367,7 @@ class DTensorV2PolicyWorker:
             with init_empty_weights():
                 self.model = custom_model_class(model_args=model_args)
         else:
+            logging.info(f"Using HuggingFace implementation for {model_name}")
             if self._is_reward_model:
                 rm_cfg = self.cfg.get("reward_model_cfg", {})
                 rm_type = rm_cfg.get("reward_model_type", "bradley_terry")

--- a/rlkit/models/policy/v2_policy_worker.py
+++ b/rlkit/models/policy/v2_policy_worker.py
@@ -599,6 +599,8 @@ class DTensorV2PolicyWorker:
                     param_groups, **self.cfg["optimizer"]["kwargs"]
                 )
             else:
+                if "muon" in self.cfg["optimizer"]["name"].lower():
+                    raise ValueError("Please specify policy.optimizer.scalar_optim to use the Muon optimizer.")
                 self.optimizer = optimizer_cls(
                     self.model.parameters(), **self.cfg["optimizer"]["kwargs"]
                 )


### PR DESCRIPTION
# What does this PR do ?

Adds support for the dion Muon optimizer interface. Use `dion.MuonReference` and specify `policy.optimizer.scalar_optim` to enable Muon optimization. Learning rate may need to be increased by around 10x for equivalent results - re-tune your hparams!