### PR TITLE
Add IcePop Masking

### DIFF
--- a/examples/configs/rl/reverser/qwen3_0.6B_2gpu_icepop.yaml
+++ b/examples/configs/rl/reverser/qwen3_0.6B_2gpu_icepop.yaml
@@ -1,0 +1,167 @@
+# GRPO Algorithm Configuration with IcePop Stabilization
+# IcePop masks out tokens where the engine mismatch ratio (training vs inference)
+# is outside acceptable bounds, preventing noisy gradient updates.
+# See: Ring-1T paper (arXiv:2510.18855)
+#
+# IcePop can be combined with either ClippedPG (GRPO) or CISPO loss functions.
+# This example demonstrates IcePop + CISPO for maximum stability.
+
+grpo:
+  num_prompts_per_step: 16
+  num_generations_per_prompt: 16
+  max_rollout_turns: 1
+  max_num_steps: 1000000
+  normalize_rewards: true
+  use_leave_one_out_baseline: true
+  val_period: 0
+  val_at_start: false
+  max_val_samples: 256
+  val_batch_size: 256
+  seed: 42
+  interleave_rollouts: true
+
+loss_fn:
+  # Can use either "cispo" or "clipped_pg" with IcePop
+  loss_type: "cispo"
+
+  # CISPO settings
+  epsilon_max: 5.0
+
+  # Shared parameters
+  reference_policy_kl_penalty: 0.0
+  use_on_policy_kl_approximation: true
+  token_level_loss: true
+
+  # IcePop settings: mask tokens where engine mismatch is outside [alpha, beta]
+  # Engine mismatch ratio = exp(prev_logprobs - generation_logprobs)
+  # = pi_train_old / pi_infer
+  icepop_enabled: true
+  icepop_alpha: 0.5   # Lower bound (default from Ring-1T paper)
+  icepop_beta: 2.0    # Upper bound (default from Ring-1T paper)
+
+checkpointing:
+  enabled: true
+  hf_checkpoint: true
+  checkpoint_dir: "results/grpo_vf_reverser_600M_icepop"
+  metric_name: "step"
+  higher_is_better: true
+  keep_top_k: 3
+  save_period: 10
+  checkpoint_must_save_by: null
+
+policy:
+  model_name: "PrimeIntellect/Qwen3-0.6B-Reverse-Text-SFT"
+  tokenizer:
+    name: ${policy.model_name}
+  train_global_batch_size: 256
+  train_micro_batch_size: 4
+  generation_batch_size: -1
+  logprob_batch_size: 4
+  max_total_sequence_length: 512
+  precision: "bfloat16"
+
+  dtensor_cfg:
+    enabled: false
+
+  dtensor_v2_cfg:
+    enabled: true
+    cpu_offload: false
+    sequence_parallel: false
+    activation_checkpointing: false
+    tensor_parallel_size: 1
+    context_parallel_size: 1
+    pipeline_parallel_size: 1
+    expert_parallel_size: 1
+    custom_parallel_plan: null
+
+  dynamic_batching:
+    enabled: False
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    sequence_length_round: 64
+
+  sequence_packing:
+    enabled: True
+    train_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.train_micro_batch_size}}
+    logprob_mb_tokens: ${mul:${policy.max_total_sequence_length}, ${policy.logprob_batch_size}}
+    algorithm: "modified_first_fit_decreasing"
+    sequence_length_round: 64
+
+  make_sequence_length_divisible_by: ${policy.dtensor_v2_cfg.tensor_parallel_size}
+  max_grad_norm: 1.0
+
+  optimizer:
+    name: "torch.optim.AdamW"
+    kwargs:
+      lr: 3.0e-6
+      weight_decay: 0.01
+      betas: [0.9, 0.999]
+      eps: 1e-8
+      foreach: False
+      fused: False
+
+  scheduler:
+    - name: "torch.optim.lr_scheduler.LinearLR"
+      kwargs:
+        start_factor: 0.1
+        end_factor: 1.0
+        total_iters: 50
+    - name: "torch.optim.lr_scheduler.ConstantLR"
+      kwargs:
+        factor: 1.0
+        total_iters: 10000000000
+    - milestones: [50]
+
+  generation:
+    backend: "vllm_http"
+    max_new_tokens: null
+    temperature: 1.0
+    top_p: 1.0
+    top_k: null
+    stop_token_ids: null
+    stop_strings: null
+    server_timeout: 60
+    vllm_cfg:
+      async_engine: false
+      precision: ${policy.precision}
+      tensor_parallel_size: 1
+      pipeline_parallel_size: 1
+      gpu_memory_utilization: 0.6
+      max_model_len: ${policy.max_total_sequence_length}
+      enforce_eager: False
+      extra_cli_args: []
+    colocated:
+      enabled: false
+      resources:
+        gpus_per_node: 1
+        num_nodes: null
+
+data:
+  max_input_seq_length: ${policy.max_total_sequence_length}
+  shuffle: false
+
+env:
+  vf:
+    environment_name: "vf_reverse_text"
+
+logger:
+  log_dir: "logs"
+  num_val_samples_to_print: 0
+  wandb_enabled: true
+  tensorboard_enabled: false
+  mlflow_enabled: false
+  monitor_gpus: true
+  wandb:
+    project: "nemo-grpo-dev"
+    name: "grpo-vf-reverser-0.6B-icepop"
+  tensorboard: {}
+  mlflow:
+    experiment_name: "grpo-vf-reverser-0.6B-icepop"
+    run_name: "grpo-vf-reverser-0.6B-icepop"
+  gpu_monitoring:
+    collection_interval: 10
+    flush_interval: 10
+
+cluster:
+  gpus_per_node: 2
+  num_nodes: 1

--- a/rlkit/algorithms/loss_functions.py
+++ b/rlkit/algorithms/loss_functions.py
@@ -251,8 +251,10 @@ class ClippedPGLossFn(LossFunction):
                 & (actor_importance_weights <= self.icepop_beta)
             ).float()
             mask = mask * icepop_mask
+            token_mask_for_loss = token_mask * icepop_mask
         else:
             original_mask = None
+            token_mask_for_loss = token_mask
 
         if self.use_importance_sampling_correction:
             importance_weights_to_use = actor_importance_weights
@@ -269,7 +271,7 @@ class ClippedPGLossFn(LossFunction):
             actor_loss = masked_mean(
                 masked_mean(
                     importance_weights_to_use * clip_loss,
-                    token_mask,
+                    token_mask_for_loss,
                     dim=-1,
                 ),
                 sample_mask,
@@ -533,8 +535,10 @@ class CISPOLossFn(LossFunction):
                 & (engine_mismatch_ratio <= self.icepop_beta)
             ).float()
             mask = mask * icepop_mask
+            token_mask_for_loss = token_mask * icepop_mask
         else:
             original_mask = None
+            token_mask_for_loss = token_mask
 
         # CISPO core: compute IS ratio, clip it, and stop gradient
         ratios = (curr_logprobs - prev_logprobs).exp()
@@ -556,7 +560,7 @@ class CISPOLossFn(LossFunction):
             )
         else:
             actor_loss = masked_mean(
-                masked_mean(cispo_loss, token_mask, dim=-1),
+                masked_mean(cispo_loss, token_mask_for_loss, dim=-1),
                 sample_mask,
                 global_normalization_factor=global_valid_seqs,
             )

--- a/rlkit/config/rl/loss.py
+++ b/rlkit/config/rl/loss.py
@@ -8,8 +8,14 @@ class ClippedPGLossConfig(TypedDict):
     use_on_policy_kl_approximation: bool
     use_importance_sampling_correction: bool
     token_level_loss: bool
+    icepop_enabled: bool      # Enable IcePop masking for engine mismatch stability
+    icepop_alpha: float       # Lower bound of acceptable mismatch ratio (default: 0.5)
+    icepop_beta: float        # Upper bound of acceptable mismatch ratio (default: 2.0)
 
 class CISPOLossConfig(TypedDict):
     epsilon_max: float
     reference_policy_kl_penalty: float
     use_on_policy_kl_approximation: bool
+    icepop_enabled: bool      # Enable IcePop masking for engine mismatch stability
+    icepop_alpha: float       # Lower bound of acceptable mismatch ratio (default: 0.5)
+    icepop_beta: float        # Upper bound of acceptable mismatch ratio (default: 2.0)

--- a/rlkit/config/rl/loss.py
+++ b/rlkit/config/rl/loss.py
@@ -16,6 +16,7 @@ class CISPOLossConfig(TypedDict):
     epsilon_max: float
     reference_policy_kl_penalty: float
     use_on_policy_kl_approximation: bool
+    token_level_loss: bool
     icepop_enabled: bool      # Enable IcePop masking for engine mismatch stability
     icepop_alpha: float       # Lower bound of acceptable mismatch ratio (default: 0.5)
     icepop_beta: float        # Upper bound of acceptable mismatch ratio (default: 2.0)


### PR DESCRIPTION
Adds IcePop stabilization from Ring-1T (arXiv:2510.18855) to both ClippedPG and CISPO loss functions.

## What it does

Masks out tokens where the engine mismatch ratio π_train/π_infer falls outside configurable bounds [alpha, beta] (default [0.5, 2.0]).

## Why hard masking vs soft weighting

We discard tokens entirely rather than downweighting them because:

1. Tokens with high engine mismatch indicate that the training and inference engines disagree significantly on the action probability. The gradient signal from these tokens is fundamentally unreliable.
2. Soft weighting would still propagate some gradient from untrustworthy samples, potentially destabilizing training
3. Binary masking is simpler to implement and reason about, with no additional hyperparameters for the weighting function shape
4. The paper's results show that hard cutoffs at [0.5, 2.0] work well in practice

## Configuration
```yaml
loss_fn:
  icepop_enabled: true
  icepop_alpha: 0.5  # lower bound
  icepop_beta: 2.0   # upper bound
```

## Monitoring

Logs `icepop_fraction_masked` metric to track what fraction of tokens are being discarded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds IcePop-based token masking to ClippedPG and CISPO losses, exposes config knobs, logs masking diagnostics, and provides an example training config.
> 
> - **Loss functions (`rlkit/algorithms/loss_functions.py`)**:
>   - **IcePop masking**: Apply token masks where engine mismatch ratio `exp(prev_logprobs - generation_logprobs)` is outside `[icepop_alpha, icepop_beta]`.
>     - Implemented in both `ClippedPGLossFn` and `CISPOLossFn`; affects `mask` and sequence-level `token_mask_for_loss`.
>     - Logs `icepop_fraction_masked` metric.
>   - **Diagnostics/efficiency**:
>     - Reuse `engine_mismatch_ratio` in CISPO for `sampling_importance_ratio`.
> - **Config types (`rlkit/config/rl/loss.py`)**:
>   - Add `icepop_enabled`, `icepop_alpha`, `icepop_beta` to `ClippedPGLossConfig` and `CISPOLossConfig`.
>   - Add `token_level_loss` to `CISPOLossConfig`.
> - **Example config**:
>   - New `examples/configs/rl/reverser/qwen3_0.6B_2gpu_icepop.yaml` demonstrating CISPO + IcePop settings and training setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbb78e7bacb48f9a07677aa7ac78c59b1a0f9372. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->